### PR TITLE
Fix/json multiple items as array

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "yargs": "^13.2.4"
   },
   "engines": {
-    "node": "8.16.0"
+    "node": ">= 8.16.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.2",

--- a/src/modules/npm-dependency-version/interfaces.ts
+++ b/src/modules/npm-dependency-version/interfaces.ts
@@ -2,6 +2,6 @@ import { IReportItem } from '../../interfaces';
 
 export interface IPacakgeVersion extends IReportItem {
   version?: string;
-  packageLockVersion?: string;
-  yarnLockVersion?: string;
+  packageLockVersion?: string[];
+  yarnLockVersion?: string[];
 }

--- a/src/modules/npm-dependency-version/package.lock.version.service.ts
+++ b/src/modules/npm-dependency-version/package.lock.version.service.ts
@@ -10,7 +10,7 @@ export class PackageLockVersionService {
   ) {
   }
 
-  public async getVersion(owner, repo, packageName, token): Promise<string> {
+  public async getVersion(owner, repo, packageName, token): Promise<string[]> {
     const packageLock = await this.getPackageLock(owner, repo, token);
     const rootVersion = get(packageLock, `dependencies.${packageName}.version`, null);
 
@@ -48,7 +48,7 @@ export class PackageLockVersionService {
       });
     }
 
-    return versions.map(({ host, version }) => `${version} for ${host}`).join('\n');
+    return versions.map(({ host, version }) => `${version} for ${host}`);
   }
 
   private async getPackageLock(owner, repo, token?: string) {

--- a/src/modules/npm-dependency-version/yarn.lock.version.service.ts
+++ b/src/modules/npm-dependency-version/yarn.lock.version.service.ts
@@ -12,7 +12,7 @@ export class YarnLockVersionService {
   ) {
   }
 
-  public async getVersion(owner, repo, packageName, token?: string): Promise<string> {
+  public async getVersion(owner, repo, packageName, token?: string): Promise<string[]> {
     const doc = await this.getYarnLock(owner, repo, token);
 
     if (doc.type !== 'success') {
@@ -65,7 +65,7 @@ export class YarnLockVersionService {
       }))
     ];
 
-    return allVersions.map(({ host, version }) => `${version} for ${host}`).join('\n');
+    return allVersions.map(({ host, version }) => `${version} for ${host}`);
   }
 
   private async getYarnLock(owner, repo, token?: string) {

--- a/src/modules/table/table.service.ts
+++ b/src/modules/table/table.service.ts
@@ -16,6 +16,11 @@ export class TableService {
     'error': Number.MAX_VALUE,
   });
 
+  private readonly TRANSFORMER = Object.freeze({
+    'packageLockVersion': versions => versions && versions.join('\n'),
+    'yarnLockVersion': versions => versions && versions.join('\n'),
+  });
+
   public format(data: IReportItem[], options: IProgramOptions): string {
     const fieldSet = data.reduce(
       (set, item) => {
@@ -42,11 +47,18 @@ export class TableService {
   
     data.forEach(item => {
       table.push({
-        [item[key] as string]: values.map(value => item[value])
+        [item[key] as string]: values.map(value => this.transform(item[value], value))
       } as any);
     });
   
     return table.toString();
+  }
+
+  private transform(value, key) {
+    // console.log(value, key);
+    return this.TRANSFORMER[key]
+      ? this.TRANSFORMER[key](value)
+      : value;
   }
 
   private filterSkippedColumns(options: IProgramOptions) {

--- a/src/modules/table/table.service.ts
+++ b/src/modules/table/table.service.ts
@@ -55,7 +55,6 @@ export class TableService {
   }
 
   private transform(value, key) {
-    // console.log(value, key);
     return this.TRANSFORMER[key]
       ? this.TRANSFORMER[key](value)
       : value;

--- a/src/util/result-filter.ts
+++ b/src/util/result-filter.ts
@@ -1,23 +1,19 @@
+import * as _ from 'lodash';
 import { IFilterOptions } from '../interfaces';
 
 export function getFilter({ skipError, skipEmpty }: IFilterOptions) {
   const filterError = ({ error }) => !error || (skipError instanceof Array ? !skipError.includes(+error) : !skipError);
 
-  // console.log(skipEmpty);
   const filterEmpty = (item) => {
     if (!skipEmpty) {
       return true;
     }
 
     const [repo, ...restKeys] = Object.keys(item);
-    const isEmpty = restKeys.map(key => item[key]).filter(x => x).length === 0;
+    const isEmpty = restKeys.map(key => item[key]).filter(x => !_.isEmpty(x)).length === 0;
 
     return !isEmpty;
   };
 
-  return item => {
-    const x = filterEmpty(item) && filterError(item);
-    // console.log(item, filterEmpty(item), filterError(item));
-    return x;
-  };
+  return item => filterEmpty(item) && filterError(item);
 }


### PR DESCRIPTION
### What

Previously multiple items was represented as string separated by `\n`.
For CLI representation inside the table it's ok, but for json it seems strange.

Leave for CLI everything as is. For json/raw json representation return multiple strings as array.
Made some changes in `getFilter()` function, because of empty array is true-equivalent value

### Chore

Switch package.json engines node version from `8.16.0` to `>= 8.16.0`

### Examples

1. CLI
![image](https://user-images.githubusercontent.com/5281274/61054520-47015f80-a3f8-11e9-84dc-82d1bde65d75.png)

2. JSON
```json
  {
    "repo": "smartextaskangular",
    "version": "~2.7.2 (dev)",
    "packageLockVersion": [
      "2.7.2 for @angular-devkit/build-optimizer",
      "2.7.2 for @schematics/angular"
    ],
    "yarnLockVersion": null
  },
```