### PR TITLE
Allow search in multiple repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-repo-tools",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Useful tool to get versions (node or npm package) from repo(s) of Github user/org",
   "main": "build/index.js",
   "bin": {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@ export interface IFilterOptions {
 export interface IOwnerOptions {
   org?: string;
   user?: string;
-  repo?: string;
+  repos?: string[];
 }
 
 export interface IPackageOptions {

--- a/src/modules/base/base.report.service.ts
+++ b/src/modules/base/base.report.service.ts
@@ -13,25 +13,17 @@ export abstract class BaseReportService<T extends IReportItem> {
   protected abstract handleRepo(repo: string, options: IProgramOptions): Promise<T>;
 
   public async getReport(options: IProgramOptions): Promise<T[]> {
-    const { org, user, token, repo } = options;
+    const { org, user, token, repos } = options;
 
-    if (repo) {
-      this.presenterService.showProcessingSpinner(options);
-      const repoReport = await this.getRepoReport(repo, options);
-      this.presenterService.hideSpinner({ success: true });
-      
-      return [repoReport];
-    }
+    const reposToSearch = repos || await this.octokitService.getRepos({ org, user, token });
 
-    const repos = await this.octokitService.getRepos({ org, user, token });
-
-    if (!repos) {
+    if (!reposToSearch) {
       return null;
     }
 
     this.presenterService.showProcessingSpinner(options);
     const result = await Promise.all(
-      repos.map(async repo => await this.getRepoReport(repo, options))
+      reposToSearch.map(async repo => await this.getRepoReport(repo, options))
     );
     this.presenterService.hideSpinner({ success: true });
 

--- a/src/modules/cli/commander.service.ts
+++ b/src/modules/cli/commander.service.ts
@@ -25,10 +25,10 @@ export class CommanderService {
         describe: 'github user where search applied',
         type: 'string',
       })
-      .option('repo', {
+      .option('repos', {
         alias: 'r',
         describe: 'github user where search applied',
-        type: 'string',
+        type: 'array',
       })
       .option('package', {
         alias: 'p',

--- a/src/modules/presenter/default.presenter.service.ts
+++ b/src/modules/presenter/default.presenter.service.ts
@@ -138,9 +138,9 @@ export class DefaultPresenterService implements IPresenterService {
   }
 
   protected getRepoToSearch(options: IProgramOptions): string {
-    const { repo } = options;
+    const { repos } = options;
 
-    return repo ? `${chalk.green(repo)}` : 'all repos';
+    return repos ? `${chalk.green(repos.join(', '))}` : 'all repos';
   }
 
 }


### PR DESCRIPTION
### What

Allow search in multiple repos

### How 

Use `-r` option multiple times: `-r <repoName1> -r <repoName2>`

Example
```
grt -n -r grt-ui -r github-repo-tools -u lightness
```